### PR TITLE
Add styling  via parts

### DIFF
--- a/.changeset/friendly-jeans-report.md
+++ b/.changeset/friendly-jeans-report.md
@@ -1,0 +1,15 @@
+---
+"@coreproject-moe/icons": patch
+---
+
+Now you can do something like
+
+```html
+<style>
+	coreproject-shape-chevron::part(svg) {
+		color: wheat;
+	}
+</style>
+```
+
+- removes the `_style` attribute

--- a/packages/icons-generator/src/generator.py
+++ b/packages/icons-generator/src/generator.py
@@ -85,16 +85,31 @@ VARIANT_DICT = {
         "left": "align-left.svg",
         "right": "align-right.svg",
     },
-    "bell": {"on": "bell.svg", "off": "bell-off.svg"},
-    "book": {"open": "book-open.svg", "close": "book.svg"},
-    "cloud": {"on": "cloud.svg", "off": "cloud-off.svg"},
-    "download": {"arrow": "download.svg", "cloud": "download-cloud.svg"},
+    "bell": {
+        "on": "bell.svg",
+        "off": "bell-off.svg",
+    },
+    "book": {
+        "open": "book-open.svg",
+        "close": "book.svg",
+    },
+    "cloud": {
+        "on": "cloud.svg",
+        "off": "cloud-off.svg",
+    },
+    "download": {
+        "arrow": "download.svg",
+        "cloud": "download-cloud.svg",
+    },
     "edit": {
         "box": "edit-box.svg",
         "pencil": "edit-pencil.svg",
         "line-with-pencil": "edit-line-with-pencil.svg",
     },
-    "eye": {"open": "eye-open.svg", "close": "eye-close.svg"},
+    "eye": {
+        "open": "eye-open.svg",
+        "close": "eye-close.svg",
+    },
     "file": {
         "normal": "file.svg",
         "minus": "file-minus.svg",
@@ -106,18 +121,27 @@ VARIANT_DICT = {
         "minus": "folder-minus.svg",
         "plus": "folder-plus.svg",
     },
-    "link": {"tilted": "link-tilted.svg", "horizontal": "link-horizontal.svg"},
+    "link": {
+        "tilted": "link-tilted.svg",
+        "horizontal": "link-horizontal.svg",
+    },
     "plus": {
         "no-border": "plus-no-border.svg",
         "circle": "plus-circle.svg",
         "square": "plus-square.svg",
     },
-    "shield": {"on": "shield.svg", "off": "shield-off.svg"},
+    "shield": {
+        "on": "shield.svg",
+        "off": "shield-off.svg",
+    },
     "trash": {
         "with-lines": "trash-with-lines.svg",
         "without-lines": "trash-without-lines.svg",
     },
-    "upload": {"arrow": "upload.svg", "cloud": "upload-cloud.svg"},
+    "upload": {
+        "arrow": "upload.svg",
+        "cloud": "upload-cloud.svg",
+    },
     "user": {
         "normal": "user.svg",
         "check": "user-check.svg",
@@ -137,12 +161,18 @@ VARIANT_DICT = {
         "octagon": "x-octagon.svg",
         "square": "x-square.svg",
     },
-    "zoom": {"in": "zoom-in.svg", "out": "zoom-out.svg"},
+    "zoom": {
+        "in": "zoom-in.svg",
+        "out": "zoom-out.svg",
+    },
     "settings": {
         "outline": "settings-outline.svg",
         "filled": "settings-filled.svg",
     },
-    "zap": {"on": "zap.svg", "off": "zap-off.svg"},
+    "zap": {
+        "on": "zap.svg",
+        "off": "zap-off.svg",
+    },
 }
 
 ICONS = []
@@ -213,7 +243,7 @@ def add_markup_to_svg(raw_svg, marker, class_variant=False):
     # Add height, width, and style to the <svg> tag
     svg_content = re.sub(
         r"(<svg[^>]*?)>",
-        rf"\1 height={{this?.height}} width={{this?.width}} style={{css_to_jsx(this?._style)}} data-marker='{marker}'>",
+        rf"\1 height={{this?.height}} width={{this?.width}} part='svg' data-marker='{marker}'>",
         svg_content,
     )
 
@@ -260,7 +290,6 @@ def make_tsx(icon_name, svg_content, variant_list=[]):
 
     return f"""
 import {{ Component, Host, h, Prop }} from '@stencil/core';
-import {{ css_to_jsx }} from '$utils/css_to_jsx';
 
 @Component({{
     tag: '{icon_name}',

--- a/packages/icons/src/components/coreproject-logo-discord/coreproject-logo-discord.tsx
+++ b/packages/icons/src/components/coreproject-logo-discord/coreproject-logo-discord.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-logo-discord",
@@ -20,7 +19,7 @@ export class CoreprojectLogoDiscord {
 					xmlns="http://www.w3.org/2000/svg"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="K"
 				>
 					<path

--- a/packages/icons/src/components/coreproject-logo-discord/readme.md
+++ b/packages/icons/src/components/coreproject-logo-discord/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-logo-figma/coreproject-logo-figma.tsx
+++ b/packages/icons/src/components/coreproject-logo-figma/coreproject-logo-figma.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-logo-figma",
@@ -24,7 +23,7 @@ export class CoreprojectLogoFigma {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="N"
 				>
 					<path d="M5 5.5A3.5 3.5 0 0 1 8.5 2H12v7H8.5A3.5 3.5 0 0 1 5 5.5z"></path>

--- a/packages/icons/src/components/coreproject-logo-figma/readme.md
+++ b/packages/icons/src/components/coreproject-logo-figma/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-logo-github/coreproject-logo-github.tsx
+++ b/packages/icons/src/components/coreproject-logo-github/coreproject-logo-github.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-logo-github",
@@ -20,7 +19,7 @@ export class CoreprojectLogoGithub {
 					xmlns="http://www.w3.org/2000/svg"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="T"
 				>
 					<g clip-path="url(#clip0_5208_6736)">

--- a/packages/icons/src/components/coreproject-logo-github/readme.md
+++ b/packages/icons/src/components/coreproject-logo-github/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-logo-reddit/coreproject-logo-reddit.tsx
+++ b/packages/icons/src/components/coreproject-logo-reddit/coreproject-logo-reddit.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-logo-reddit",
@@ -20,7 +19,7 @@ export class CoreprojectLogoReddit {
 					xmlns="http://www.w3.org/2000/svg"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0s"
 				>
 					<g clip-path="url(#clip0_5206_8638)">

--- a/packages/icons/src/components/coreproject-logo-reddit/readme.md
+++ b/packages/icons/src/components/coreproject-logo-reddit/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-airplay/coreproject-shape-airplay.tsx
+++ b/packages/icons/src/components/coreproject-shape-airplay/coreproject-shape-airplay.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-airplay",
@@ -24,7 +23,7 @@ export class CoreprojectShapeAirplay {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="t"
 				>
 					<path d="M5 17H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-1"></path>

--- a/packages/icons/src/components/coreproject-shape-airplay/readme.md
+++ b/packages/icons/src/components/coreproject-shape-airplay/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-alert-triangle/coreproject-shape-alert-triangle.tsx
+++ b/packages/icons/src/components/coreproject-shape-alert-triangle/coreproject-shape-alert-triangle.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-alert-triangle",
@@ -24,7 +23,7 @@ export class CoreprojectShapeAlertTriangle {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="u"
 				>
 					<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>

--- a/packages/icons/src/components/coreproject-shape-alert-triangle/readme.md
+++ b/packages/icons/src/components/coreproject-shape-alert-triangle/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-align/coreproject-shape-align.tsx
+++ b/packages/icons/src/components/coreproject-shape-align/coreproject-shape-align.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-align",
@@ -33,7 +32,7 @@ export class CoreprojectShapeAlign {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="9"
 					>
 						<line x1="18" y1="10" x2="6" y2="10"></line>
@@ -56,7 +55,7 @@ export class CoreprojectShapeAlign {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="9"
 					>
 						<line x1="21" y1="10" x2="3" y2="10"></line>
@@ -79,7 +78,7 @@ export class CoreprojectShapeAlign {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="9"
 					>
 						<line x1="17" y1="10" x2="3" y2="10"></line>
@@ -102,7 +101,7 @@ export class CoreprojectShapeAlign {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="9"
 					>
 						<line x1="21" y1="10" x2="7" y2="10"></line>

--- a/packages/icons/src/components/coreproject-shape-align/readme.md
+++ b/packages/icons/src/components/coreproject-shape-align/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"center" \| "justify" \| "left" \| "right"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                           | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-arrow/coreproject-shape-arrow.tsx
+++ b/packages/icons/src/components/coreproject-shape-arrow/coreproject-shape-arrow.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-arrow",
@@ -32,7 +31,7 @@ export class CoreprojectShapeArrow {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="6"
 					class={this?.variant}
 				>

--- a/packages/icons/src/components/coreproject-shape-arrow/readme.md
+++ b/packages/icons/src/components/coreproject-shape-arrow/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"down" \| "left" \| "right" \| "up"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                    | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-at-sign/coreproject-shape-at-sign.tsx
+++ b/packages/icons/src/components/coreproject-shape-at-sign/coreproject-shape-at-sign.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-at-sign",
@@ -24,7 +23,7 @@ export class CoreprojectShapeAtSign {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="v"
 				>
 					<circle cx="12" cy="12" r="4"></circle>

--- a/packages/icons/src/components/coreproject-shape-at-sign/readme.md
+++ b/packages/icons/src/components/coreproject-shape-at-sign/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-award/coreproject-shape-award.tsx
+++ b/packages/icons/src/components/coreproject-shape-award/coreproject-shape-award.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-award",
@@ -24,7 +23,7 @@ export class CoreprojectShapeAward {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="w"
 				>
 					<circle cx="12" cy="8" r="7"></circle>

--- a/packages/icons/src/components/coreproject-shape-award/readme.md
+++ b/packages/icons/src/components/coreproject-shape-award/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-bar-chart/coreproject-shape-bar-chart.tsx
+++ b/packages/icons/src/components/coreproject-shape-bar-chart/coreproject-shape-bar-chart.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-bar-chart",
@@ -24,7 +23,7 @@ export class CoreprojectShapeBarChart {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="x"
 				>
 					<line x1="12" y1="20" x2="12" y2="10"></line>

--- a/packages/icons/src/components/coreproject-shape-bar-chart/readme.md
+++ b/packages/icons/src/components/coreproject-shape-bar-chart/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-bell/coreproject-shape-bell.tsx
+++ b/packages/icons/src/components/coreproject-shape-bell/coreproject-shape-bell.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-bell",
@@ -31,7 +30,7 @@ export class CoreprojectShapeBell {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="a"
 					>
 						<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
@@ -52,7 +51,7 @@ export class CoreprojectShapeBell {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="a"
 					>
 						<path d="M13.73 21a2 2 0 0 1-3.46 0"></path>

--- a/packages/icons/src/components/coreproject-shape-bell/readme.md
+++ b/packages/icons/src/components/coreproject-shape-bell/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"off" \| "on"`    | `undefined` |
 | `width`                | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-bold/coreproject-shape-bold.tsx
+++ b/packages/icons/src/components/coreproject-shape-bold/coreproject-shape-bold.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-bold",
@@ -24,7 +23,7 @@ export class CoreprojectShapeBold {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="y"
 				>
 					<path d="M6 4h8a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z"></path>

--- a/packages/icons/src/components/coreproject-shape-bold/readme.md
+++ b/packages/icons/src/components/coreproject-shape-bold/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-book/coreproject-shape-book.tsx
+++ b/packages/icons/src/components/coreproject-shape-book/coreproject-shape-book.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-book",
@@ -31,7 +30,7 @@ export class CoreprojectShapeBook {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="b"
 					>
 						<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path>
@@ -52,7 +51,7 @@ export class CoreprojectShapeBook {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="b"
 					>
 						<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path>

--- a/packages/icons/src/components/coreproject-shape-book/readme.md
+++ b/packages/icons/src/components/coreproject-shape-book/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"close" \| "open"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`  | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-box/coreproject-shape-box.tsx
+++ b/packages/icons/src/components/coreproject-shape-box/coreproject-shape-box.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-box",
@@ -24,7 +23,7 @@ export class CoreprojectShapeBox {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="z"
 				>
 					<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>

--- a/packages/icons/src/components/coreproject-shape-box/readme.md
+++ b/packages/icons/src/components/coreproject-shape-box/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-calendar/coreproject-shape-calendar.tsx
+++ b/packages/icons/src/components/coreproject-shape-calendar/coreproject-shape-calendar.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-calendar",
@@ -24,7 +23,7 @@ export class CoreprojectShapeCalendar {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="A"
 				>
 					<rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>

--- a/packages/icons/src/components/coreproject-shape-calendar/readme.md
+++ b/packages/icons/src/components/coreproject-shape-calendar/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-cast/coreproject-shape-cast.tsx
+++ b/packages/icons/src/components/coreproject-shape-cast/coreproject-shape-cast.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-cast",
@@ -24,7 +23,7 @@ export class CoreprojectShapeCast {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="B"
 				>
 					<path d="M2 16.1A5 5 0 0 1 5.9 20M2 12.05A9 9 0 0 1 9.95 20M2 8V6a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-6"></path>

--- a/packages/icons/src/components/coreproject-shape-cast/readme.md
+++ b/packages/icons/src/components/coreproject-shape-cast/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-check/coreproject-shape-check.tsx
+++ b/packages/icons/src/components/coreproject-shape-check/coreproject-shape-check.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-check",
@@ -24,7 +23,7 @@ export class CoreprojectShapeCheck {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="C"
 				>
 					<polyline points="20 6 9 17 4 12"></polyline>

--- a/packages/icons/src/components/coreproject-shape-check/readme.md
+++ b/packages/icons/src/components/coreproject-shape-check/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-chevron/coreproject-shape-chevron.tsx
+++ b/packages/icons/src/components/coreproject-shape-chevron/coreproject-shape-chevron.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-chevron",
@@ -32,7 +31,7 @@ export class CoreprojectShapeChevron {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0"
 					class={this?.variant}
 				>

--- a/packages/icons/src/components/coreproject-shape-chevron/readme.md
+++ b/packages/icons/src/components/coreproject-shape-chevron/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"down" \| "left" \| "right" \| "up"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                    | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-chevrons/coreproject-shape-chevrons.tsx
+++ b/packages/icons/src/components/coreproject-shape-chevrons/coreproject-shape-chevrons.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-chevrons",
@@ -32,7 +31,7 @@ export class CoreprojectShapeChevrons {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="1"
 					class={this?.variant}
 				>

--- a/packages/icons/src/components/coreproject-shape-chevrons/readme.md
+++ b/packages/icons/src/components/coreproject-shape-chevrons/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"down" \| "left" \| "right" \| "up"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                    | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-circle/coreproject-shape-circle.tsx
+++ b/packages/icons/src/components/coreproject-shape-circle/coreproject-shape-circle.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-circle",
@@ -30,7 +29,7 @@ export class CoreprojectShapeCircle {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="8"
 					class={this?.variant}
 				>

--- a/packages/icons/src/components/coreproject-shape-circle/readme.md
+++ b/packages/icons/src/components/coreproject-shape-circle/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"filled" \| "outline"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`      | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-clipboard/coreproject-shape-clipboard.tsx
+++ b/packages/icons/src/components/coreproject-shape-clipboard/coreproject-shape-clipboard.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-clipboard",
@@ -24,7 +23,7 @@ export class CoreprojectShapeClipboard {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="D"
 				>
 					<path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>

--- a/packages/icons/src/components/coreproject-shape-clipboard/readme.md
+++ b/packages/icons/src/components/coreproject-shape-clipboard/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-clock/coreproject-shape-clock.tsx
+++ b/packages/icons/src/components/coreproject-shape-clock/coreproject-shape-clock.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-clock",
@@ -24,7 +23,7 @@ export class CoreprojectShapeClock {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="E"
 				>
 					<circle cx="12" cy="12" r="10"></circle>

--- a/packages/icons/src/components/coreproject-shape-clock/readme.md
+++ b/packages/icons/src/components/coreproject-shape-clock/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-cloud/coreproject-shape-cloud.tsx
+++ b/packages/icons/src/components/coreproject-shape-cloud/coreproject-shape-cloud.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-cloud",
@@ -31,7 +30,7 @@ export class CoreprojectShapeCloud {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="c"
 					>
 						<path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"></path>
@@ -51,7 +50,7 @@ export class CoreprojectShapeCloud {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="c"
 					>
 						<path d="M22.61 16.95A5 5 0 0 0 18 10h-1.26a8 8 0 0 0-7.05-6M5 5a8 8 0 0 0 4 15h9a5 5 0 0 0 1.7-.3"></path>

--- a/packages/icons/src/components/coreproject-shape-cloud/readme.md
+++ b/packages/icons/src/components/coreproject-shape-cloud/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"off" \| "on"`    | `undefined` |
 | `width`                | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-code/coreproject-shape-code.tsx
+++ b/packages/icons/src/components/coreproject-shape-code/coreproject-shape-code.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-code",
@@ -24,7 +23,7 @@ export class CoreprojectShapeCode {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="F"
 				>
 					<polyline points="16 18 22 12 16 6"></polyline>

--- a/packages/icons/src/components/coreproject-shape-code/readme.md
+++ b/packages/icons/src/components/coreproject-shape-code/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-compass/coreproject-shape-compass.tsx
+++ b/packages/icons/src/components/coreproject-shape-compass/coreproject-shape-compass.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-compass",
@@ -24,7 +23,7 @@ export class CoreprojectShapeCompass {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="G"
 				>
 					<circle cx="12" cy="12" r="10"></circle>

--- a/packages/icons/src/components/coreproject-shape-compass/readme.md
+++ b/packages/icons/src/components/coreproject-shape-compass/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-copy/coreproject-shape-copy.tsx
+++ b/packages/icons/src/components/coreproject-shape-copy/coreproject-shape-copy.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-copy",
@@ -24,7 +23,7 @@ export class CoreprojectShapeCopy {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="H"
 				>
 					<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>

--- a/packages/icons/src/components/coreproject-shape-copy/readme.md
+++ b/packages/icons/src/components/coreproject-shape-copy/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-corner/coreproject-shape-corner.tsx
+++ b/packages/icons/src/components/coreproject-shape-corner/coreproject-shape-corner.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-corner",
@@ -51,7 +50,7 @@ export class CoreprojectShapeCorner {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="4"
 					class={this?.variant}
 				>

--- a/packages/icons/src/components/coreproject-shape-corner/readme.md
+++ b/packages/icons/src/components/coreproject-shape-corner/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"down-left" \| "down-right" \| "left-down" \| "left-up" \| "right-down" \| "right-up" \| "up-left" \| "up-right"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                                                                                                 | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-delete/coreproject-shape-delete.tsx
+++ b/packages/icons/src/components/coreproject-shape-delete/coreproject-shape-delete.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-delete",
@@ -24,7 +23,7 @@ export class CoreprojectShapeDelete {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="I"
 				>
 					<path d="M21 4H8l-7 8 7 8h13a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z"></path>

--- a/packages/icons/src/components/coreproject-shape-delete/readme.md
+++ b/packages/icons/src/components/coreproject-shape-delete/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-dice/coreproject-shape-dice.tsx
+++ b/packages/icons/src/components/coreproject-shape-dice/coreproject-shape-dice.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-dice",
@@ -20,7 +19,7 @@ export class CoreprojectShapeDice {
 					xmlns="http://www.w3.org/2000/svg"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="J"
 				>
 					<path

--- a/packages/icons/src/components/coreproject-shape-dice/readme.md
+++ b/packages/icons/src/components/coreproject-shape-dice/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-download/coreproject-shape-download.tsx
+++ b/packages/icons/src/components/coreproject-shape-download/coreproject-shape-download.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-download",
@@ -31,7 +30,7 @@ export class CoreprojectShapeDownload {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="d"
 					>
 						<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
@@ -53,7 +52,7 @@ export class CoreprojectShapeDownload {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="d"
 					>
 						<polyline points="8 17 12 21 16 17"></polyline>

--- a/packages/icons/src/components/coreproject-shape-download/readme.md
+++ b/packages/icons/src/components/coreproject-shape-download/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"arrow" \| "cloud"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`   | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-edit/coreproject-shape-edit.tsx
+++ b/packages/icons/src/components/coreproject-shape-edit/coreproject-shape-edit.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-edit",
@@ -33,7 +32,7 @@ export class CoreprojectShapeEdit {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="e"
 					>
 						<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
@@ -54,7 +53,7 @@ export class CoreprojectShapeEdit {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="e"
 					>
 						<path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path>
@@ -74,7 +73,7 @@ export class CoreprojectShapeEdit {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="e"
 					>
 						<path d="M12 20h9"></path>

--- a/packages/icons/src/components/coreproject-shape-edit/readme.md
+++ b/packages/icons/src/components/coreproject-shape-edit/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"box" \| "line-with-pencil" \| "pencil"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                        | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-expand/coreproject-shape-expand.tsx
+++ b/packages/icons/src/components/coreproject-shape-expand/coreproject-shape-expand.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-expand",
@@ -24,7 +23,7 @@ export class CoreprojectShapeExpand {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="L"
 				>
 					<polyline points="15 3 21 3 21 9"></polyline>

--- a/packages/icons/src/components/coreproject-shape-expand/readme.md
+++ b/packages/icons/src/components/coreproject-shape-expand/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-external-link/coreproject-shape-external-link.tsx
+++ b/packages/icons/src/components/coreproject-shape-external-link/coreproject-shape-external-link.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-external-link",
@@ -24,7 +23,7 @@ export class CoreprojectShapeExternalLink {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="M"
 				>
 					<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>

--- a/packages/icons/src/components/coreproject-shape-external-link/readme.md
+++ b/packages/icons/src/components/coreproject-shape-external-link/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-eye/coreproject-shape-eye.tsx
+++ b/packages/icons/src/components/coreproject-shape-eye/coreproject-shape-eye.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-eye",
@@ -31,7 +30,7 @@ export class CoreprojectShapeEye {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="f"
 					>
 						<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
@@ -52,7 +51,7 @@ export class CoreprojectShapeEye {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="f"
 					>
 						<path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>

--- a/packages/icons/src/components/coreproject-shape-eye/readme.md
+++ b/packages/icons/src/components/coreproject-shape-eye/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"close" \| "open"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`  | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-file/coreproject-shape-file.tsx
+++ b/packages/icons/src/components/coreproject-shape-file/coreproject-shape-file.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-file",
@@ -33,7 +32,7 @@ export class CoreprojectShapeFile {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="g"
 					>
 						<path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"></path>
@@ -54,7 +53,7 @@ export class CoreprojectShapeFile {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="g"
 					>
 						<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
@@ -76,7 +75,7 @@ export class CoreprojectShapeFile {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="g"
 					>
 						<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
@@ -99,7 +98,7 @@ export class CoreprojectShapeFile {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="g"
 					>
 						<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>

--- a/packages/icons/src/components/coreproject-shape-file/readme.md
+++ b/packages/icons/src/components/coreproject-shape-file/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"minus" \| "normal" \| "plus" \| "text"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                        | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-filter/coreproject-shape-filter.tsx
+++ b/packages/icons/src/components/coreproject-shape-filter/coreproject-shape-filter.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-filter",
@@ -24,7 +23,7 @@ export class CoreprojectShapeFilter {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="O"
 				>
 					<polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>

--- a/packages/icons/src/components/coreproject-shape-filter/readme.md
+++ b/packages/icons/src/components/coreproject-shape-filter/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-flag/coreproject-shape-flag.tsx
+++ b/packages/icons/src/components/coreproject-shape-flag/coreproject-shape-flag.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-flag",
@@ -24,7 +23,7 @@ export class CoreprojectShapeFlag {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="P"
 				>
 					<path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"></path>

--- a/packages/icons/src/components/coreproject-shape-flag/readme.md
+++ b/packages/icons/src/components/coreproject-shape-flag/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-folder/coreproject-shape-folder.tsx
+++ b/packages/icons/src/components/coreproject-shape-folder/coreproject-shape-folder.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-folder",
@@ -33,7 +32,7 @@ export class CoreprojectShapeFolder {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="h"
 					>
 						<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
@@ -53,7 +52,7 @@ export class CoreprojectShapeFolder {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="h"
 					>
 						<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
@@ -74,7 +73,7 @@ export class CoreprojectShapeFolder {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="h"
 					>
 						<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>

--- a/packages/icons/src/components/coreproject-shape-folder/readme.md
+++ b/packages/icons/src/components/coreproject-shape-folder/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"minus" \| "normal" \| "plus"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`              | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-forum/coreproject-shape-forum.tsx
+++ b/packages/icons/src/components/coreproject-shape-forum/coreproject-shape-forum.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-forum",
@@ -20,7 +19,7 @@ export class CoreprojectShapeForum {
 					xmlns="http://www.w3.org/2000/svg"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="Q"
 				>
 					<g clip-path="url(#clip0_5206_8612)">

--- a/packages/icons/src/components/coreproject-shape-forum/readme.md
+++ b/packages/icons/src/components/coreproject-shape-forum/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-frown/coreproject-shape-frown.tsx
+++ b/packages/icons/src/components/coreproject-shape-frown/coreproject-shape-frown.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-frown",
@@ -24,7 +23,7 @@ export class CoreprojectShapeFrown {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="R"
 				>
 					<circle cx="12" cy="12" r="10"></circle>

--- a/packages/icons/src/components/coreproject-shape-frown/readme.md
+++ b/packages/icons/src/components/coreproject-shape-frown/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-gift/coreproject-shape-gift.tsx
+++ b/packages/icons/src/components/coreproject-shape-gift/coreproject-shape-gift.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-gift",
@@ -24,7 +23,7 @@ export class CoreprojectShapeGift {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="S"
 				>
 					<polyline points="20 12 20 22 4 22 4 12"></polyline>

--- a/packages/icons/src/components/coreproject-shape-gift/readme.md
+++ b/packages/icons/src/components/coreproject-shape-gift/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-globe/coreproject-shape-globe.tsx
+++ b/packages/icons/src/components/coreproject-shape-globe/coreproject-shape-globe.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-globe",
@@ -24,7 +23,7 @@ export class CoreprojectShapeGlobe {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="U"
 				>
 					<circle cx="12" cy="12" r="10"></circle>

--- a/packages/icons/src/components/coreproject-shape-globe/readme.md
+++ b/packages/icons/src/components/coreproject-shape-globe/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-grid/coreproject-shape-grid.tsx
+++ b/packages/icons/src/components/coreproject-shape-grid/coreproject-shape-grid.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-grid",
@@ -24,7 +23,7 @@ export class CoreprojectShapeGrid {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="V"
 				>
 					<rect x="3" y="3" width="7" height="7"></rect>

--- a/packages/icons/src/components/coreproject-shape-grid/readme.md
+++ b/packages/icons/src/components/coreproject-shape-grid/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-hard-drive/coreproject-shape-hard-drive.tsx
+++ b/packages/icons/src/components/coreproject-shape-hard-drive/coreproject-shape-hard-drive.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-hard-drive",
@@ -24,7 +23,7 @@ export class CoreprojectShapeHardDrive {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="W"
 				>
 					<line x1="22" y1="12" x2="2" y2="12"></line>

--- a/packages/icons/src/components/coreproject-shape-hard-drive/readme.md
+++ b/packages/icons/src/components/coreproject-shape-hard-drive/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-hash/coreproject-shape-hash.tsx
+++ b/packages/icons/src/components/coreproject-shape-hash/coreproject-shape-hash.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-hash",
@@ -24,7 +23,7 @@ export class CoreprojectShapeHash {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="X"
 				>
 					<line x1="4" y1="9" x2="20" y2="9"></line>

--- a/packages/icons/src/components/coreproject-shape-hash/readme.md
+++ b/packages/icons/src/components/coreproject-shape-hash/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-headphones/coreproject-shape-headphones.tsx
+++ b/packages/icons/src/components/coreproject-shape-headphones/coreproject-shape-headphones.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-headphones",
@@ -24,7 +23,7 @@ export class CoreprojectShapeHeadphones {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="Y"
 				>
 					<path d="M3 18v-6a9 9 0 0 1 18 0v6"></path>

--- a/packages/icons/src/components/coreproject-shape-headphones/readme.md
+++ b/packages/icons/src/components/coreproject-shape-headphones/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-heart/coreproject-shape-heart.tsx
+++ b/packages/icons/src/components/coreproject-shape-heart/coreproject-shape-heart.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-heart",
@@ -24,7 +23,7 @@ export class CoreprojectShapeHeart {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="Z"
 				>
 					<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>

--- a/packages/icons/src/components/coreproject-shape-heart/readme.md
+++ b/packages/icons/src/components/coreproject-shape-heart/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-help-circle/coreproject-shape-help-circle.tsx
+++ b/packages/icons/src/components/coreproject-shape-help-circle/coreproject-shape-help-circle.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-help-circle",
@@ -24,7 +23,7 @@ export class CoreprojectShapeHelpCircle {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="00"
 				>
 					<circle cx="12" cy="12" r="10"></circle>

--- a/packages/icons/src/components/coreproject-shape-help-circle/readme.md
+++ b/packages/icons/src/components/coreproject-shape-help-circle/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-home/coreproject-shape-home.tsx
+++ b/packages/icons/src/components/coreproject-shape-home/coreproject-shape-home.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-home",
@@ -24,7 +23,7 @@ export class CoreprojectShapeHome {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="01"
 				>
 					<path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>

--- a/packages/icons/src/components/coreproject-shape-home/readme.md
+++ b/packages/icons/src/components/coreproject-shape-home/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-info/coreproject-shape-info.tsx
+++ b/packages/icons/src/components/coreproject-shape-info/coreproject-shape-info.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-info",
@@ -24,7 +23,7 @@ export class CoreprojectShapeInfo {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="02"
 				>
 					<circle cx="12" cy="12" r="10"></circle>

--- a/packages/icons/src/components/coreproject-shape-info/readme.md
+++ b/packages/icons/src/components/coreproject-shape-info/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-italic/coreproject-shape-italic.tsx
+++ b/packages/icons/src/components/coreproject-shape-italic/coreproject-shape-italic.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-italic",
@@ -24,7 +23,7 @@ export class CoreprojectShapeItalic {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="03"
 				>
 					<line x1="19" y1="4" x2="10" y2="4"></line>

--- a/packages/icons/src/components/coreproject-shape-italic/readme.md
+++ b/packages/icons/src/components/coreproject-shape-italic/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-key/coreproject-shape-key.tsx
+++ b/packages/icons/src/components/coreproject-shape-key/coreproject-shape-key.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-key",
@@ -24,7 +23,7 @@ export class CoreprojectShapeKey {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="04"
 				>
 					<path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"></path>

--- a/packages/icons/src/components/coreproject-shape-key/readme.md
+++ b/packages/icons/src/components/coreproject-shape-key/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-link/coreproject-shape-link.tsx
+++ b/packages/icons/src/components/coreproject-shape-link/coreproject-shape-link.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-link",
@@ -31,7 +30,7 @@ export class CoreprojectShapeLink {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="i"
 					>
 						<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
@@ -52,7 +51,7 @@ export class CoreprojectShapeLink {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="i"
 					>
 						<path d="M15 7h3a5 5 0 0 1 5 5 5 5 0 0 1-5 5h-3m-6 0H6a5 5 0 0 1-5-5 5 5 0 0 1 5-5h3"></path>

--- a/packages/icons/src/components/coreproject-shape-link/readme.md
+++ b/packages/icons/src/components/coreproject-shape-link/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"horizontal" \| "tilted"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`         | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-list/coreproject-shape-list.tsx
+++ b/packages/icons/src/components/coreproject-shape-list/coreproject-shape-list.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-list",
@@ -24,7 +23,7 @@ export class CoreprojectShapeList {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="05"
 				>
 					<line x1="8" y1="6" x2="21" y2="6"></line>

--- a/packages/icons/src/components/coreproject-shape-list/readme.md
+++ b/packages/icons/src/components/coreproject-shape-list/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-lock/coreproject-shape-lock.tsx
+++ b/packages/icons/src/components/coreproject-shape-lock/coreproject-shape-lock.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-lock",
@@ -24,7 +23,7 @@ export class CoreprojectShapeLock {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="06"
 				>
 					<rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>

--- a/packages/icons/src/components/coreproject-shape-lock/readme.md
+++ b/packages/icons/src/components/coreproject-shape-lock/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-log-in/coreproject-shape-log-in.tsx
+++ b/packages/icons/src/components/coreproject-shape-log-in/coreproject-shape-log-in.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-log-in",
@@ -24,7 +23,7 @@ export class CoreprojectShapeLogIn {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="07"
 				>
 					<path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"></path>

--- a/packages/icons/src/components/coreproject-shape-log-in/readme.md
+++ b/packages/icons/src/components/coreproject-shape-log-in/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-log-out/coreproject-shape-log-out.tsx
+++ b/packages/icons/src/components/coreproject-shape-log-out/coreproject-shape-log-out.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-log-out",
@@ -24,7 +23,7 @@ export class CoreprojectShapeLogOut {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="08"
 				>
 					<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>

--- a/packages/icons/src/components/coreproject-shape-log-out/readme.md
+++ b/packages/icons/src/components/coreproject-shape-log-out/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-logo/coreproject-shape-logo.tsx
+++ b/packages/icons/src/components/coreproject-shape-logo/coreproject-shape-logo.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-logo",
@@ -20,7 +19,7 @@ export class CoreprojectShapeLogo {
 					xmlns="http://www.w3.org/2000/svg"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="09"
 				>
 					<path

--- a/packages/icons/src/components/coreproject-shape-logo/readme.md
+++ b/packages/icons/src/components/coreproject-shape-logo/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-mail/coreproject-shape-mail.tsx
+++ b/packages/icons/src/components/coreproject-shape-mail/coreproject-shape-mail.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-mail",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMail {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0a"
 				>
 					<path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>

--- a/packages/icons/src/components/coreproject-shape-mail/readme.md
+++ b/packages/icons/src/components/coreproject-shape-mail/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-map-pin/coreproject-shape-map-pin.tsx
+++ b/packages/icons/src/components/coreproject-shape-map-pin/coreproject-shape-map-pin.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-map-pin",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMapPin {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0b"
 				>
 					<path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path>

--- a/packages/icons/src/components/coreproject-shape-map-pin/readme.md
+++ b/packages/icons/src/components/coreproject-shape-map-pin/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-maximize/coreproject-shape-maximize.tsx
+++ b/packages/icons/src/components/coreproject-shape-maximize/coreproject-shape-maximize.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-maximize",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMaximize {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0c"
 				>
 					<path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"></path>

--- a/packages/icons/src/components/coreproject-shape-maximize/readme.md
+++ b/packages/icons/src/components/coreproject-shape-maximize/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-media-skip/coreproject-shape-media-skip.tsx
+++ b/packages/icons/src/components/coreproject-shape-media-skip/coreproject-shape-media-skip.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-media-skip",
@@ -32,7 +31,7 @@ export class CoreprojectShapeMediaSkip {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="7"
 					class={this?.variant}
 				>

--- a/packages/icons/src/components/coreproject-shape-media-skip/readme.md
+++ b/packages/icons/src/components/coreproject-shape-media-skip/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"fast-forward" \| "rewind"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`           | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-meh/coreproject-shape-meh.tsx
+++ b/packages/icons/src/components/coreproject-shape-meh/coreproject-shape-meh.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-meh",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMeh {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0d"
 				>
 					<circle cx="12" cy="12" r="10"></circle>

--- a/packages/icons/src/components/coreproject-shape-meh/readme.md
+++ b/packages/icons/src/components/coreproject-shape-meh/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-menu/coreproject-shape-menu.tsx
+++ b/packages/icons/src/components/coreproject-shape-menu/coreproject-shape-menu.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-menu",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMenu {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0e"
 				>
 					<line x1="3" y1="12" x2="21" y2="12"></line>

--- a/packages/icons/src/components/coreproject-shape-menu/readme.md
+++ b/packages/icons/src/components/coreproject-shape-menu/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-message-circle/coreproject-shape-message-circle.tsx
+++ b/packages/icons/src/components/coreproject-shape-message-circle/coreproject-shape-message-circle.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-message-circle",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMessageCircle {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0f"
 				>
 					<path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path>

--- a/packages/icons/src/components/coreproject-shape-message-circle/readme.md
+++ b/packages/icons/src/components/coreproject-shape-message-circle/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-minimize/coreproject-shape-minimize.tsx
+++ b/packages/icons/src/components/coreproject-shape-minimize/coreproject-shape-minimize.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-minimize",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMinimize {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0g"
 				>
 					<path d="M8 3v3a2 2 0 0 1-2 2H3m18 0h-3a2 2 0 0 1-2-2V3m0 18v-3a2 2 0 0 1 2-2h3M3 16h3a2 2 0 0 1 2 2v3"></path>

--- a/packages/icons/src/components/coreproject-shape-minimize/readme.md
+++ b/packages/icons/src/components/coreproject-shape-minimize/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-minus/coreproject-shape-minus.tsx
+++ b/packages/icons/src/components/coreproject-shape-minus/coreproject-shape-minus.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-minus",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMinus {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0h"
 				>
 					<line x1="5" y1="12" x2="19" y2="12"></line>

--- a/packages/icons/src/components/coreproject-shape-minus/readme.md
+++ b/packages/icons/src/components/coreproject-shape-minus/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-monitor/coreproject-shape-monitor.tsx
+++ b/packages/icons/src/components/coreproject-shape-monitor/coreproject-shape-monitor.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-monitor",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMonitor {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0i"
 				>
 					<rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>

--- a/packages/icons/src/components/coreproject-shape-monitor/readme.md
+++ b/packages/icons/src/components/coreproject-shape-monitor/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-moon/coreproject-shape-moon.tsx
+++ b/packages/icons/src/components/coreproject-shape-moon/coreproject-shape-moon.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-moon",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMoon {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0j"
 				>
 					<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>

--- a/packages/icons/src/components/coreproject-shape-moon/readme.md
+++ b/packages/icons/src/components/coreproject-shape-moon/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-more/coreproject-shape-more.tsx
+++ b/packages/icons/src/components/coreproject-shape-more/coreproject-shape-more.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-more",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMore {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0k"
 				>
 					<circle cx="12" cy="12" r="1"></circle>

--- a/packages/icons/src/components/coreproject-shape-more/readme.md
+++ b/packages/icons/src/components/coreproject-shape-more/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-mouse-pointer/coreproject-shape-mouse-pointer.tsx
+++ b/packages/icons/src/components/coreproject-shape-mouse-pointer/coreproject-shape-mouse-pointer.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-mouse-pointer",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMousePointer {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0l"
 				>
 					<path d="M3 3l7.07 16.97 2.51-7.39 7.39-2.51L3 3z"></path>

--- a/packages/icons/src/components/coreproject-shape-mouse-pointer/readme.md
+++ b/packages/icons/src/components/coreproject-shape-mouse-pointer/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-move/coreproject-shape-move.tsx
+++ b/packages/icons/src/components/coreproject-shape-move/coreproject-shape-move.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-move",
@@ -24,7 +23,7 @@ export class CoreprojectShapeMove {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0m"
 				>
 					<polyline points="5 9 2 12 5 15"></polyline>

--- a/packages/icons/src/components/coreproject-shape-move/readme.md
+++ b/packages/icons/src/components/coreproject-shape-move/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-pause-circle/coreproject-shape-pause-circle.tsx
+++ b/packages/icons/src/components/coreproject-shape-pause-circle/coreproject-shape-pause-circle.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-pause-circle",
@@ -24,7 +23,7 @@ export class CoreprojectShapePauseCircle {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0n"
 				>
 					<circle cx="12" cy="12" r="10"></circle>

--- a/packages/icons/src/components/coreproject-shape-pause-circle/readme.md
+++ b/packages/icons/src/components/coreproject-shape-pause-circle/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-pause/coreproject-shape-pause.tsx
+++ b/packages/icons/src/components/coreproject-shape-pause/coreproject-shape-pause.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-pause",
@@ -24,7 +23,7 @@ export class CoreprojectShapePause {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0o"
 				>
 					<rect x="6" y="4" width="4" height="16"></rect>

--- a/packages/icons/src/components/coreproject-shape-pause/readme.md
+++ b/packages/icons/src/components/coreproject-shape-pause/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-play-circle/coreproject-shape-play-circle.tsx
+++ b/packages/icons/src/components/coreproject-shape-play-circle/coreproject-shape-play-circle.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-play-circle",
@@ -24,7 +23,7 @@ export class CoreprojectShapePlayCircle {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0p"
 				>
 					<circle cx="12" cy="12" r="10"></circle>

--- a/packages/icons/src/components/coreproject-shape-play-circle/readme.md
+++ b/packages/icons/src/components/coreproject-shape-play-circle/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-play/coreproject-shape-play.tsx
+++ b/packages/icons/src/components/coreproject-shape-play/coreproject-shape-play.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-play",
@@ -24,7 +23,7 @@ export class CoreprojectShapePlay {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0q"
 				>
 					<polygon points="5 3 19 12 5 21 5 3"></polygon>

--- a/packages/icons/src/components/coreproject-shape-play/readme.md
+++ b/packages/icons/src/components/coreproject-shape-play/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-plus/coreproject-shape-plus.tsx
+++ b/packages/icons/src/components/coreproject-shape-plus/coreproject-shape-plus.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-plus",
@@ -33,7 +32,7 @@ export class CoreprojectShapePlus {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="j"
 					>
 						<line x1="12" y1="5" x2="12" y2="19"></line>
@@ -54,7 +53,7 @@ export class CoreprojectShapePlus {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="j"
 					>
 						<circle cx="12" cy="12" r="10"></circle>
@@ -76,7 +75,7 @@ export class CoreprojectShapePlus {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="j"
 					>
 						<rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>

--- a/packages/icons/src/components/coreproject-shape-plus/readme.md
+++ b/packages/icons/src/components/coreproject-shape-plus/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"circle" \| "no-border" \| "square"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                    | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-preferences/coreproject-shape-preferences.tsx
+++ b/packages/icons/src/components/coreproject-shape-preferences/coreproject-shape-preferences.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-preferences",
@@ -24,7 +23,7 @@ export class CoreprojectShapePreferences {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0r"
 				>
 					<line x1="4" y1="21" x2="4" y2="14"></line>

--- a/packages/icons/src/components/coreproject-shape-preferences/readme.md
+++ b/packages/icons/src/components/coreproject-shape-preferences/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-refresh/coreproject-shape-refresh.tsx
+++ b/packages/icons/src/components/coreproject-shape-refresh/coreproject-shape-refresh.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-refresh",
@@ -24,7 +23,7 @@ export class CoreprojectShapeRefresh {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0t"
 				>
 					<polyline points="23 4 23 10 17 10"></polyline>

--- a/packages/icons/src/components/coreproject-shape-refresh/readme.md
+++ b/packages/icons/src/components/coreproject-shape-refresh/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-repeat/coreproject-shape-repeat.tsx
+++ b/packages/icons/src/components/coreproject-shape-repeat/coreproject-shape-repeat.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-repeat",
@@ -24,7 +23,7 @@ export class CoreprojectShapeRepeat {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0u"
 				>
 					<polyline points="17 1 21 5 17 9"></polyline>

--- a/packages/icons/src/components/coreproject-shape-repeat/readme.md
+++ b/packages/icons/src/components/coreproject-shape-repeat/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-rotate/coreproject-shape-rotate.tsx
+++ b/packages/icons/src/components/coreproject-shape-rotate/coreproject-shape-rotate.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-rotate",
@@ -24,7 +23,7 @@ export class CoreprojectShapeRotate {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0v"
 				>
 					<polyline points="23 4 23 10 17 10"></polyline>

--- a/packages/icons/src/components/coreproject-shape-rotate/readme.md
+++ b/packages/icons/src/components/coreproject-shape-rotate/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-save/coreproject-shape-save.tsx
+++ b/packages/icons/src/components/coreproject-shape-save/coreproject-shape-save.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-save",
@@ -24,7 +23,7 @@ export class CoreprojectShapeSave {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0w"
 				>
 					<path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>

--- a/packages/icons/src/components/coreproject-shape-save/readme.md
+++ b/packages/icons/src/components/coreproject-shape-save/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-search/coreproject-shape-search.tsx
+++ b/packages/icons/src/components/coreproject-shape-search/coreproject-shape-search.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-search",
@@ -24,7 +23,7 @@ export class CoreprojectShapeSearch {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0x"
 				>
 					<circle cx="11" cy="11" r="8"></circle>

--- a/packages/icons/src/components/coreproject-shape-search/readme.md
+++ b/packages/icons/src/components/coreproject-shape-search/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-settings/coreproject-shape-settings.tsx
+++ b/packages/icons/src/components/coreproject-shape-settings/coreproject-shape-settings.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-settings",
@@ -33,7 +32,7 @@ export class CoreprojectShapeSettings {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="r"
 					>
 						<circle cx="12" cy="12" r="3"></circle>
@@ -50,7 +49,7 @@ export class CoreprojectShapeSettings {
 						xmlns="http://www.w3.org/2000/svg"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="r"
 					>
 						<path

--- a/packages/icons/src/components/coreproject-shape-settings/readme.md
+++ b/packages/icons/src/components/coreproject-shape-settings/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"filled" \| "outline"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`      | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-share/coreproject-shape-share.tsx
+++ b/packages/icons/src/components/coreproject-shape-share/coreproject-shape-share.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-share",
@@ -24,7 +23,7 @@ export class CoreprojectShapeShare {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0y"
 				>
 					<circle cx="18" cy="5" r="3"></circle>

--- a/packages/icons/src/components/coreproject-shape-share/readme.md
+++ b/packages/icons/src/components/coreproject-shape-share/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-shield/coreproject-shape-shield.tsx
+++ b/packages/icons/src/components/coreproject-shape-shield/coreproject-shape-shield.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-shield",
@@ -31,7 +30,7 @@ export class CoreprojectShapeShield {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="k"
 					>
 						<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
@@ -51,7 +50,7 @@ export class CoreprojectShapeShield {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="k"
 					>
 						<path d="M19.69 14a6.9 6.9 0 0 0 .31-2V5l-8-3-3.16 1.18"></path>

--- a/packages/icons/src/components/coreproject-shape-shield/readme.md
+++ b/packages/icons/src/components/coreproject-shape-shield/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"off" \| "on"`    | `undefined` |
 | `width`                | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-shopping-cart/coreproject-shape-shopping-cart.tsx
+++ b/packages/icons/src/components/coreproject-shape-shopping-cart/coreproject-shape-shopping-cart.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-shopping-cart",
@@ -24,7 +23,7 @@ export class CoreprojectShapeShoppingCart {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0z"
 				>
 					<circle cx="9" cy="21" r="1"></circle>

--- a/packages/icons/src/components/coreproject-shape-shopping-cart/readme.md
+++ b/packages/icons/src/components/coreproject-shape-shopping-cart/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-shrink/coreproject-shape-shrink.tsx
+++ b/packages/icons/src/components/coreproject-shape-shrink/coreproject-shape-shrink.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-shrink",
@@ -24,7 +23,7 @@ export class CoreprojectShapeShrink {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0A"
 				>
 					<polyline points="4 14 10 14 10 20"></polyline>

--- a/packages/icons/src/components/coreproject-shape-shrink/readme.md
+++ b/packages/icons/src/components/coreproject-shape-shrink/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-smartphone/coreproject-shape-smartphone.tsx
+++ b/packages/icons/src/components/coreproject-shape-smartphone/coreproject-shape-smartphone.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-smartphone",
@@ -24,7 +23,7 @@ export class CoreprojectShapeSmartphone {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0B"
 				>
 					<rect x="5" y="2" width="14" height="20" rx="2" ry="2"></rect>

--- a/packages/icons/src/components/coreproject-shape-smartphone/readme.md
+++ b/packages/icons/src/components/coreproject-shape-smartphone/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-smile/coreproject-shape-smile.tsx
+++ b/packages/icons/src/components/coreproject-shape-smile/coreproject-shape-smile.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-smile",
@@ -24,7 +23,7 @@ export class CoreprojectShapeSmile {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0C"
 				>
 					<circle cx="12" cy="12" r="10"></circle>

--- a/packages/icons/src/components/coreproject-shape-smile/readme.md
+++ b/packages/icons/src/components/coreproject-shape-smile/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-speaker/coreproject-shape-speaker.tsx
+++ b/packages/icons/src/components/coreproject-shape-speaker/coreproject-shape-speaker.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-speaker",
@@ -24,7 +23,7 @@ export class CoreprojectShapeSpeaker {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0D"
 				>
 					<rect x="4" y="2" width="16" height="20" rx="2" ry="2"></rect>

--- a/packages/icons/src/components/coreproject-shape-speaker/readme.md
+++ b/packages/icons/src/components/coreproject-shape-speaker/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-star/coreproject-shape-star.tsx
+++ b/packages/icons/src/components/coreproject-shape-star/coreproject-shape-star.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-star",
@@ -24,7 +23,7 @@ export class CoreprojectShapeStar {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0E"
 				>
 					<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>

--- a/packages/icons/src/components/coreproject-shape-star/readme.md
+++ b/packages/icons/src/components/coreproject-shape-star/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-sun/coreproject-shape-sun.tsx
+++ b/packages/icons/src/components/coreproject-shape-sun/coreproject-shape-sun.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-sun",
@@ -24,7 +23,7 @@ export class CoreprojectShapeSun {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0F"
 				>
 					<circle cx="12" cy="12" r="5"></circle>

--- a/packages/icons/src/components/coreproject-shape-sun/readme.md
+++ b/packages/icons/src/components/coreproject-shape-sun/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-tag/coreproject-shape-tag.tsx
+++ b/packages/icons/src/components/coreproject-shape-tag/coreproject-shape-tag.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-tag",
@@ -24,7 +23,7 @@ export class CoreprojectShapeTag {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0G"
 				>
 					<path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>

--- a/packages/icons/src/components/coreproject-shape-tag/readme.md
+++ b/packages/icons/src/components/coreproject-shape-tag/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-terminal/coreproject-shape-terminal.tsx
+++ b/packages/icons/src/components/coreproject-shape-terminal/coreproject-shape-terminal.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-terminal",
@@ -24,7 +23,7 @@ export class CoreprojectShapeTerminal {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0H"
 				>
 					<polyline points="4 17 10 11 4 5"></polyline>

--- a/packages/icons/src/components/coreproject-shape-terminal/readme.md
+++ b/packages/icons/src/components/coreproject-shape-terminal/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-thumbs/coreproject-shape-thumbs.tsx
+++ b/packages/icons/src/components/coreproject-shape-thumbs/coreproject-shape-thumbs.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-thumbs",
@@ -30,7 +29,7 @@ export class CoreprojectShapeThumbs {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="2"
 					class={this?.variant}
 				>

--- a/packages/icons/src/components/coreproject-shape-thumbs/readme.md
+++ b/packages/icons/src/components/coreproject-shape-thumbs/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"down" \| "up"`   | `undefined` |
 | `width`                | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-toggle/coreproject-shape-toggle.tsx
+++ b/packages/icons/src/components/coreproject-shape-toggle/coreproject-shape-toggle.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-toggle",
@@ -30,7 +29,7 @@ export class CoreprojectShapeToggle {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="5"
 					class={this?.variant}
 				>

--- a/packages/icons/src/components/coreproject-shape-toggle/readme.md
+++ b/packages/icons/src/components/coreproject-shape-toggle/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"off" \| "on"`    | `undefined` |
 | `width`                | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-tool/coreproject-shape-tool.tsx
+++ b/packages/icons/src/components/coreproject-shape-tool/coreproject-shape-tool.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-tool",
@@ -24,7 +23,7 @@ export class CoreprojectShapeTool {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0I"
 				>
 					<path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path>

--- a/packages/icons/src/components/coreproject-shape-tool/readme.md
+++ b/packages/icons/src/components/coreproject-shape-tool/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-trash/coreproject-shape-trash.tsx
+++ b/packages/icons/src/components/coreproject-shape-trash/coreproject-shape-trash.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-trash",
@@ -33,7 +32,7 @@ export class CoreprojectShapeTrash {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="l"
 					>
 						<polyline points="3 6 5 6 21 6"></polyline>
@@ -56,7 +55,7 @@ export class CoreprojectShapeTrash {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="l"
 					>
 						<polyline points="3 6 5 6 21 6"></polyline>

--- a/packages/icons/src/components/coreproject-shape-trash/readme.md
+++ b/packages/icons/src/components/coreproject-shape-trash/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"with-lines" \| "without-lines"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-trending/coreproject-shape-trending.tsx
+++ b/packages/icons/src/components/coreproject-shape-trending/coreproject-shape-trending.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-trending",
@@ -30,7 +29,7 @@ export class CoreprojectShapeTrending {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="3"
 					class={this?.variant}
 				>

--- a/packages/icons/src/components/coreproject-shape-trending/readme.md
+++ b/packages/icons/src/components/coreproject-shape-trending/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"down" \| "up"`   | `undefined` |
 | `width`                | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-triangle/coreproject-shape-triangle.tsx
+++ b/packages/icons/src/components/coreproject-shape-triangle/coreproject-shape-triangle.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-triangle",
@@ -24,7 +23,7 @@ export class CoreprojectShapeTriangle {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0J"
 				>
 					<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>

--- a/packages/icons/src/components/coreproject-shape-triangle/readme.md
+++ b/packages/icons/src/components/coreproject-shape-triangle/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-twitter/coreproject-shape-twitter.tsx
+++ b/packages/icons/src/components/coreproject-shape-twitter/coreproject-shape-twitter.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-twitter",
@@ -24,7 +23,7 @@ export class CoreprojectShapeTwitter {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0K"
 				>
 					<path d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z"></path>

--- a/packages/icons/src/components/coreproject-shape-twitter/readme.md
+++ b/packages/icons/src/components/coreproject-shape-twitter/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-type/coreproject-shape-type.tsx
+++ b/packages/icons/src/components/coreproject-shape-type/coreproject-shape-type.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-type",
@@ -24,7 +23,7 @@ export class CoreprojectShapeType {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0L"
 				>
 					<polyline points="4 7 4 4 20 4 20 7"></polyline>

--- a/packages/icons/src/components/coreproject-shape-type/readme.md
+++ b/packages/icons/src/components/coreproject-shape-type/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-underline/coreproject-shape-underline.tsx
+++ b/packages/icons/src/components/coreproject-shape-underline/coreproject-shape-underline.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-underline",
@@ -24,7 +23,7 @@ export class CoreprojectShapeUnderline {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0M"
 				>
 					<path d="M6 3v7a6 6 0 0 0 6 6 6 6 0 0 0 6-6V3"></path>

--- a/packages/icons/src/components/coreproject-shape-underline/readme.md
+++ b/packages/icons/src/components/coreproject-shape-underline/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-unlock/coreproject-shape-unlock.tsx
+++ b/packages/icons/src/components/coreproject-shape-unlock/coreproject-shape-unlock.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-unlock",
@@ -24,7 +23,7 @@ export class CoreprojectShapeUnlock {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0N"
 				>
 					<rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>

--- a/packages/icons/src/components/coreproject-shape-unlock/readme.md
+++ b/packages/icons/src/components/coreproject-shape-unlock/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-upload/coreproject-shape-upload.tsx
+++ b/packages/icons/src/components/coreproject-shape-upload/coreproject-shape-upload.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-upload",
@@ -31,7 +30,7 @@ export class CoreprojectShapeUpload {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="m"
 					>
 						<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
@@ -53,7 +52,7 @@ export class CoreprojectShapeUpload {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="m"
 					>
 						<polyline points="16 16 12 12 8 16"></polyline>

--- a/packages/icons/src/components/coreproject-shape-upload/readme.md
+++ b/packages/icons/src/components/coreproject-shape-upload/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"arrow" \| "cloud"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`   | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-user/coreproject-shape-user.tsx
+++ b/packages/icons/src/components/coreproject-shape-user/coreproject-shape-user.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-user",
@@ -33,7 +32,7 @@ export class CoreprojectShapeUser {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="n"
 					>
 						<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
@@ -54,7 +53,7 @@ export class CoreprojectShapeUser {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="n"
 					>
 						<path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
@@ -76,7 +75,7 @@ export class CoreprojectShapeUser {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="n"
 					>
 						<path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
@@ -98,7 +97,7 @@ export class CoreprojectShapeUser {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="n"
 					>
 						<path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
@@ -121,7 +120,7 @@ export class CoreprojectShapeUser {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="n"
 					>
 						<path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>

--- a/packages/icons/src/components/coreproject-shape-user/readme.md
+++ b/packages/icons/src/components/coreproject-shape-user/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"check" \| "minus" \| "normal" \| "plus" \| "x"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                                | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-users/coreproject-shape-users.tsx
+++ b/packages/icons/src/components/coreproject-shape-users/coreproject-shape-users.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-users",
@@ -24,7 +23,7 @@ export class CoreprojectShapeUsers {
 					stroke-linejoin="round"
 					height={this?.height}
 					width={this?.width}
-					style={css_to_jsx(this?._style)}
+					part="svg"
 					data-marker="0O"
 				>
 					<path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>

--- a/packages/icons/src/components/coreproject-shape-users/readme.md
+++ b/packages/icons/src/components/coreproject-shape-users/readme.md
@@ -10,6 +10,12 @@
 | `height` | `height`  |             | `number \| string` | `undefined` |
 | `width`  | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-volume/coreproject-shape-volume.tsx
+++ b/packages/icons/src/components/coreproject-shape-volume/coreproject-shape-volume.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-volume",
@@ -33,7 +32,7 @@ export class CoreprojectShapeVolume {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="o"
 					>
 						<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
@@ -53,7 +52,7 @@ export class CoreprojectShapeVolume {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="o"
 					>
 						<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
@@ -74,7 +73,7 @@ export class CoreprojectShapeVolume {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="o"
 					>
 						<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
@@ -95,7 +94,7 @@ export class CoreprojectShapeVolume {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="o"
 					>
 						<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>

--- a/packages/icons/src/components/coreproject-shape-volume/readme.md
+++ b/packages/icons/src/components/coreproject-shape-volume/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"full" \| "half" \| "mute" \| "off"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                    | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-x/coreproject-shape-x.tsx
+++ b/packages/icons/src/components/coreproject-shape-x/coreproject-shape-x.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-x",
@@ -33,7 +32,7 @@ export class CoreprojectShapeX {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="p"
 					>
 						<line x1="18" y1="6" x2="6" y2="18"></line>
@@ -54,7 +53,7 @@ export class CoreprojectShapeX {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="p"
 					>
 						<circle cx="12" cy="12" r="10"></circle>
@@ -76,7 +75,7 @@ export class CoreprojectShapeX {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="p"
 					>
 						<polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"></polygon>
@@ -98,7 +97,7 @@ export class CoreprojectShapeX {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="p"
 					>
 						<rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>

--- a/packages/icons/src/components/coreproject-shape-x/readme.md
+++ b/packages/icons/src/components/coreproject-shape-x/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"circle" \| "no-border" \| "octagon" \| "square"` | `undefined` |
 | `width`                | `width`   |             | `number \| string`                                 | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-zap/coreproject-shape-zap.tsx
+++ b/packages/icons/src/components/coreproject-shape-zap/coreproject-shape-zap.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-zap",
@@ -31,7 +30,7 @@ export class CoreprojectShapeZap {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="s"
 					>
 						<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon>
@@ -51,7 +50,7 @@ export class CoreprojectShapeZap {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="s"
 					>
 						<polyline points="12.41 6.75 13 2 10.57 4.92"></polyline>

--- a/packages/icons/src/components/coreproject-shape-zap/readme.md
+++ b/packages/icons/src/components/coreproject-shape-zap/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"off" \| "on"`    | `undefined` |
 | `width`                | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/components/coreproject-shape-zoom/coreproject-shape-zoom.tsx
+++ b/packages/icons/src/components/coreproject-shape-zoom/coreproject-shape-zoom.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, h, Prop } from "@stencil/core";
-import { css_to_jsx } from "$utils/css_to_jsx";
 
 @Component({
 	tag: "coreproject-shape-zoom",
@@ -31,7 +30,7 @@ export class CoreprojectShapeZoom {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="q"
 					>
 						<circle cx="11" cy="11" r="8"></circle>
@@ -54,7 +53,7 @@ export class CoreprojectShapeZoom {
 						stroke-linejoin="round"
 						height={this?.height}
 						width={this?.width}
-						style={css_to_jsx(this?._style)}
+						part="svg"
 						data-marker="q"
 					>
 						<circle cx="11" cy="11" r="8"></circle>

--- a/packages/icons/src/components/coreproject-shape-zoom/readme.md
+++ b/packages/icons/src/components/coreproject-shape-zoom/readme.md
@@ -11,6 +11,12 @@
 | `variant` _(required)_ | `variant` |             | `"in" \| "out"`    | `undefined` |
 | `width`                | `width`   |             | `number \| string` | `undefined` |
 
+## Shadow Parts
+
+| Part    | Description |
+| ------- | ----------- |
+| `"svg"` |             |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/icons/src/index.html
+++ b/packages/icons/src/index.html
@@ -12,6 +12,11 @@
 		<script nomodule src="/build/coreproject-icons.js"></script>
 	</head>
 	<body>
-		<coreproject-shape-chevron variant="up" style="color: white" />
+		<coreproject-shape-chevron variant="up" />
+		<style>
+			coreproject-shape-chevron::part(svg) {
+				color: wheat;
+			}
+		</style>
 	</body>
 </html>

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -9,4 +9,3 @@
  */
 
 export type * from "./components.d.ts";
-export { css_to_jsx } from "$utils/css_to_jsx";

--- a/packages/icons/src/utils/css_to_jsx.ts
+++ b/packages/icons/src/utils/css_to_jsx.ts
@@ -1,8 +1,0 @@
-export const css_to_jsx = (css: string | undefined) => {
-	if (!css) return {};
-
-	const r = /(?<=^|;)\s*([^:]+)\s*:\s*([^;]+)\s*/g,
-		o = {};
-	css.replace(r, (_, p, v) => (o[p] = v));
-	return o;
-};

--- a/packages/icons/src/utils/is_number.ts
+++ b/packages/icons/src/utils/is_number.ts
@@ -1,3 +1,0 @@
-export function is_number(n: unknown) {
-	return !isNaN(parseFloat(n as string)) && !isNaN(Number(n) - 0);
-}


### PR DESCRIPTION
Closes #https://github.com/coreproject-moe/monorepo/issues/97 


Now you can do something like 


```html
<style>
	coreproject-shape-chevron::part(svg) {
		color: wheat;
	}
</style>
```

- removes the `_style` attribute